### PR TITLE
fix: reset needsContactInfo when user logs in mid chat session

### DIFF
--- a/app/components/common/FloatingContact.vue
+++ b/app/components/common/FloatingContact.vue
@@ -261,6 +261,7 @@ onBeforeUnmount(() => {
 
 watch(accessToken, async (newToken, oldToken) => {
 	if (newToken && !oldToken && sessionId.value) {
+		needsContactInfo.value = false;
 		try {
 			await storeChatRepository.linkToCustomer(sessionId.value);
 		} catch {


### PR DESCRIPTION
needsContactInfo was only computed once inside initChat() when the widget first opens, so logging in afterward left the name/phone form showing until a full page reload re-ran initChat() with the now-truthy accessToken.